### PR TITLE
Fix 2023 Quality-data format

### DIFF
--- a/hydenv/examples/hobo.py
+++ b/hydenv/examples/hobo.py
@@ -198,7 +198,7 @@ class HydenvHoboExamples:
             if data == 'all' or data == 'quality':
                 # quality checked data
                 p = os.path.join(path, self.__hobo_data_map[term], 'hourly')
-                cli.folder(path=p, match=r'[0-9]+_Th\.(tsv|csv)', is_quality=True, term=term, quiet=quiet)
+                cli.folder(path=p, match=r'[0-9]+_(T|t)h\.(tsv|csv)', is_quality=True, term=term, quiet=quiet)
 
     def remove_term(self, term: str, quiet=True):
         """"""


### PR DESCRIPTION
Since 2023 the `*_Th.csv` can also be `*_th.csv` and the `dttm` format was changed from ISO-8601 to '%Y.%m.%d %H:%M:%S', which is accepted additionally.

@maxschmi, maybe we can switch back to the old ddtm format for 2024 again...